### PR TITLE
fix: empty blockquote

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -200,7 +200,8 @@ const plugin: Plugin = (customConfig?: Partial<Config>) => {
 
   return function (tree) {
     visit(tree, "blockquote", (node: Node) => {
-      if (!("children" in node)) return;
+      if (!("children" in node) || (node as Parent).children.length == 0)
+        return;
 
       const firstChild = (node as Parent).children[0];
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -54,6 +54,12 @@ describe("test default behavior", () => {
 
   const infoInput = `> [!info] This is an info callout.`;
 
+  it("should ignore empty blockquote", async () => {
+    const html = await parseMarkdown("> ", {}, false);
+    const expectedOutput = `<blockquote></blockquote>`;
+    expect(normalizeHtml(html)).toBe(normalizeHtml(expectedOutput));
+  });
+
   it("should render a note blockquote", async () => {
     const html = await parseMarkdown(noteInput, {}, false);
     const expectedOutput = `


### PR DESCRIPTION
This PR fixed a bug when the plugin would fail on empty blockquote. I have implemented a fix and added a test case for it.